### PR TITLE
Update the q2-SCNIC build recipe to build the plugin for qiime2-2020.6

### DIFF
--- a/build_recipe.sh
+++ b/build_recipe.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 conda build q2-SCNIC-recipe/ \
-    -c https://conda.anaconda.org/qiime2/label/r2018.11 \
+    -c https://conda.anaconda.org/qiime2/label/r2020.06 \
     -c https://conda.anaconda.org/qiime2 \
     -c https://conda.anaconda.org/conda-forge \
     -c defaults \
     -c https://conda.anaconda.org/bioconda \
     -c https://conda.anaconda.org/biocore \
      --override-channels \
-     --python 3.5
+     --python 3.6

--- a/q2-SCNIC-recipe/meta.yaml
+++ b/q2-SCNIC-recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2018.11.0" %}
+{% set version = "2020.06.0" %}
 
 package:
   name: q2-scnic
@@ -14,13 +14,13 @@ build:
 
 requirements:
   host:
-    - python =3.5.*
+    - python =3.6.*
     - setuptools
   run:
-    - python =3.5.*
+    - python =3.6.*
     - scnic >=0.6.*
-    - qiime2 =2018.11*
-    - q2-types =2018.11.*
+    - qiime2 =2020.06*
+    - q2-types =2020.06.*
 
 test:
   imports:


### PR DESCRIPTION
This update to the build recipe allows q2-SCNIC to be built with qiime2-2020.6. All tests run cleanly.