### PR TITLE
Update _SCNIC_methods.py to match signature of filter_correls()

### DIFF
--- a/q2_SCNIC/_SCNIC_methods.py
+++ b/q2_SCNIC/_SCNIC_methods.py
@@ -40,7 +40,7 @@ def build_correlation_network_r(correlation_table: pd.DataFrame, min_val: float=
 
 
 def build_correlation_network_p(correlation_table: pd.DataFrame, max_val: float=.05) -> nx.Graph:
-    correlation_table_filtered = filter_correls(correlation_table, min_p=max_val)
+    correlation_table_filtered = filter_correls(correlation_table, max_p=max_val)
     net = correls_to_net(correlation_table_filtered)
     return net
 


### PR DESCRIPTION
`filter_correls()` in SCNIC takes a max_p parameter, but the `build_correlation_network_p()` function in _SCNIC_methods.py specifies a `min_p` parameter when calling `filter_correls()`, resulting in an error when running `qiime SCNIC build-correlation-network-p`

This pull request fixes #14 